### PR TITLE
Fix HTML Tidy link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HTML Tidy for PostHTML
 
-[HTML Tidy](html-tidy.org) corrects and cleans up HTML and XML documents by fixing markup errors and upgrading legacy code to modern standards.
+[HTML Tidy](http://html-tidy.org) corrects and cleans up HTML and XML documents by fixing markup errors and upgrading legacy code to modern standards.
 
 ## Install
 


### PR DESCRIPTION
Link was missing the `http://` protocol
