### PR TITLE
asynchronously return the tidied tree

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,14 @@ const chalk = require('chalk')
 const tidy = require('htmltidy2').tidy
 
 const render = require('posthtml-render')
+const parser = require('posthtml-parser')
+
+const log = function (err, msg) {
+  if (err) {
+    console.log(chalk.red(err))
+  }
+  console.log(chalk.green(msg))
+}
 
 exports = module.exports = function (options) {
   options = options || {}
@@ -16,14 +24,18 @@ exports = module.exports = function (options) {
   options.rules = options.rules || {}
 
   return function PostHTMLTidy (tree) {
-    tidy(render(tree), options.rules, (err, msg) => {
-      if (options.log === true) {
-        if (err) {
-          console.log(chalk.red(err))
+    return new Promise((resolve, reject) => {
+      tidy(render(tree), options.rules, (err, msg) => {
+        if (options.log) {
+          log(err, msg)
         }
-        console.log(chalk.green(msg))
-      }
+
+        if (err) {
+          reject(err || new Error('Unknown problem in posthtml-tidy.'))
+        }
+
+        resolve(parser(msg))
+      })
     })
-    return tree
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "chalk": "^1.1.1",
     "htmltidy2": "^0.1.4",
+    "posthtml-parser": "^0.2.0",
     "posthtml-render": "^1.0.5"
   },
   "devDependencies": {},


### PR DESCRIPTION
I noticed that htmltidy options which typically result in changes to the input markup, such as dropping empty tags, weren't reflected in output files. To all appearances, if the `log` option is not set to true, posthtml-tidy "doesn't do anything."

This is because the input tree is passed immediately out again without any changes. This pull request parses htmltidy's output back into a tree and returns that tree instead (as a Promise resolution).